### PR TITLE
direct Arch Linux users to package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Or use pathogen and just clone the git repository:
     $ cd ~/.vim/bundle
     $ git clone https://github.com/gioele/vim-autoswap.git
 
+Arch Linux can install via [a package in the AUR](https://aur.archlinux.org/packages/vim-autoswap-git/).
+
 *Linux users*: you must install `wmctrl` to be able to automatically
 switch to the Vim window with the open file.
 `wmctrl` is already packaged for most distributions.


### PR DESCRIPTION
I created a package for Arch Linux to easily install this plugin, including dependencies. You may want to notify your users about this in the [README](README.md).