### PR TITLE
Add support for using tmux panes for focusing rather than windows

### DIFF
--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -119,7 +119,7 @@ endfunction
 
 " TMUX: Detection function for tmux, uses tmux
 function! AS_DetectActiveWindow_Tmux (swapname)
-	let find_win_cmd = 'tmux list-panes -aF "#{pane_tty} #{window_index} #{pane_index}"| grep $(ps h $(fuser '.a:swapname.' | cut -d" " -f2) | cut -d" " -f2)'
+	let find_win_cmd = 'tmux list-panes -aF "#{pane_tty} #{window_index} #{pane_index}"| grep $(ps h $(fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*" || echo "^$") 2>/dev/null | cut -d" " -f3) 2>/dev/null'
 	return system(find_win_cmd)
 endfunction
 

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -119,7 +119,7 @@ endfunction
 
 " TMUX: Detection function for tmux, uses tmux
 function! AS_DetectActiveWindow_Tmux (swapname)
-	let find_win_cmd = 'tmux list-panes -aF "#{pane_tty} #{window_index} #{pane_index}"| grep $(ps h $(fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*" || echo "^$") 2>/dev/null | cut -d" " -f3) 2>/dev/null'
+	let find_win_cmd = 'tmux list-panes -aF "#{pane_tty} #{window_index} #{pane_index}"| grep $(ps h $(fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*" || echo "^$") 2>/dev/null | sed "s/^ *//" | cut -d" " -f2) 2>/dev/null'
 	return system(find_win_cmd)
 endfunction
 
@@ -155,7 +155,7 @@ endfunction
 " TMUX: Switch function for Tmux
 function! AS_SwitchToActiveWindow_Tmux (active_window)
 	let pane_info = split(a:active_window)
-	call system('tmux select-window -t '.get(pane_info, 2 , '').'; tmux select-pane -t '.get(pane_info, 3 , ''))
+	call system('tmux select-window -t '.get(pane_info, 1 , '').'; tmux select-pane -t '.get(pane_info, 2 , ''))
 endfunction
 
 " LINUX: Switch function for Linux, uses wmctrl


### PR DESCRIPTION
Autoswap to tmux pane with the file open. (works for any window/pane in the same tmux session)
I haven't tested it on OSX nor with gvim, but tmux 1.9 with vim 7.4.273 works great.

Might need to make AS_DetectActiveWindow_Tmux a little clearer and AS_RunningTmux a bit more robust. But works for me.