### PR TITLE
No more need for setting the terminal's window title

### DIFF
--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -145,7 +145,7 @@ function! AS_DetectActiveWindow_Linux (swapname)
 	if (len(pid) == 0)
 		return ''
 	endif
-	for servername in split(serverlist())
+	for servername in split(serverlist(), "\n")
 		if pid[0] == remote_expr(servername, 'getpid()')
 			return remote_expr(servername, 'v:windowid')
 		endif

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -139,12 +139,17 @@ function! AS_DetectActiveWindow_Tmux (swapname)
 	return window[0]
 endfunction
 
-" LINUX: Detection function for Linux, uses proc fs and WINDOWID env var
+" LINUX: Detection function for Linux, uses +clientserver, proc fs and WINDOWID env var
 function! AS_DetectActiveWindow_Linux (swapname)
 	let pid = systemlist('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"')
 	if (len(pid) == 0)
 		return ''
 	endif
+	for servername in split(serverlist())
+		if pid[0] == remote_expr(servername, 'getpid()')
+			return remote_expr(servername, 'v:windowid')
+		endif
+	endfor
 	let env = readfile('/proc/'.pid[0].'/environ', 'b')
 	if (len(env) == 0)
 		return ''

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -141,7 +141,7 @@ endfunction
 
 " LINUX: Detection function for Linux, uses +clientserver, proc fs and WINDOWID env var
 function! AS_DetectActiveWindow_Linux (swapname)
-	let pid = systemlist('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"')
+	let pid = split(system('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"'), '\n')
 	if (len(pid) == 0)
 		return ''
 	endif

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -147,11 +147,15 @@ function! AS_DetectActiveWindow_Linux (swapname)
 	endif
 	let pid = pids[0]
 
+	" get the window ID from the remote window, if +clientserver
+	" functionality is available
 	for servername in split(serverlist(), "\n")
 		if pid == remote_expr(servername, 'getpid()')
 			return remote_expr(servername, 'v:windowid')
 		endif
 	endfor
+
+	" read WINDOWID from the pid's env if +clientserver is not available
 	let env = readfile('/proc/'.pid.'/environ', 'b')
 	if (len(env) == 0)
 		return ''

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -150,7 +150,7 @@ function! AS_DetectActiveWindow_Linux (swapname)
 		return ''
 	endif
 	let active_window = matchstr('\n'.env[0].'\n', '\nWINDOWID=\zs\(0x\)\?\d\+\ze\n')
-	return (active_window =~ '^\(0x\)\?\d\+$' ? active_window : "")
+	return (active_window =~ '\v^(0x)?\x+$' ? active_window : "")
 endfunction
 
 " MAC: Detection function for Mac OSX, uses osascript

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -154,15 +154,15 @@ function! AS_DetectActiveWindow_Linux (swapname)
 				return remote_expr(servername, 'v:windowid')
 			endif
 		endfor
-	else
-		" read WINDOWID from the pid's env
-		let env = readfile('/proc/'.pid.'/environ', 'b')
-		if (len(env) == 0)
-			return ''
-		endif
-		let active_window = matchstr('\n'.env[0].'\n', '\nWINDOWID=\zs\(0x\)\?\d\+\ze\n')
-		return (active_window =~ '\v^(0x)?\x+$' ? active_window : "")
 	endif
+
+	" read WINDOWID from the pid's env
+	let env = readfile('/proc/'.pid.'/environ', 'b')
+	if (len(env) == 0)
+		return ''
+	endif
+	let active_window = matchstr('\n'.env[0].'\n', '\nWINDOWID=\zs\(0x\)\?\d\+\ze\n')
+	return (active_window =~ '\v^(0x)?\x+$' ? active_window : "")
 endfunction
 
 " MAC: Detection function for Mac OSX, uses osascript

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -141,16 +141,18 @@ endfunction
 
 " LINUX: Detection function for Linux, uses +clientserver, proc fs and WINDOWID env var
 function! AS_DetectActiveWindow_Linux (swapname)
-	let pid = split(system('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"'), '\n')
-	if (len(pid) == 0)
+	let pids = split(system('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"'), '\n')
+	if (len(pids) == 0)
 		return ''
 	endif
+	let pid = pids[0]
+
 	for servername in split(serverlist(), "\n")
-		if pid[0] == remote_expr(servername, 'getpid()')
+		if pid == remote_expr(servername, 'getpid()')
 			return remote_expr(servername, 'v:windowid')
 		endif
 	endfor
-	let env = readfile('/proc/'.pid[0].'/environ', 'b')
+	let env = readfile('/proc/'.pid.'/environ', 'b')
 	if (len(env) == 0)
 		return ''
 	endif

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -117,7 +117,7 @@ function! AS_DetectActiveWindow (filename, swapname)
 	elseif has('macunix')
 		let active_window = AS_DetectActiveWindow_Mac(a:filename)
 	elseif has('unix')
-		let active_window = AS_DetectActiveWindow_Linux(a:filename)
+		let active_window = AS_DetectActiveWindow_Linux(a:swapname)
 	endif
 	return active_window
 endfunction
@@ -139,12 +139,18 @@ function! AS_DetectActiveWindow_Tmux (swapname)
 	return window[0]
 endfunction
 
-" LINUX: Detection function for Linux, uses mwctrl
-function! AS_DetectActiveWindow_Linux (filename)
-	let shortname = fnamemodify(a:filename,":t")
-	let find_win_cmd = 'wmctrl -l | grep -i " '.shortname.' .*vim" | tail -n1 | cut -d" " -f1'
-	let active_window = system(find_win_cmd)
-	return (active_window =~ '0x' ? active_window : "")
+" LINUX: Detection function for Linux, uses proc fs and WINDOWID env var
+function! AS_DetectActiveWindow_Linux (swapname)
+	let pid = systemlist('fuser '.a:swapname.' 2>/dev/null | grep -o "[0-9]*"')
+	if (len(pid) == 0)
+		return ''
+	endif
+	let env = readfile('/proc/'.pid[0].'/environ', 'b')
+	if (len(env) == 0)
+		return ''
+	endif
+	let active_window = matchstr('\n'.env[0].'\n', '\nWINDOWID=\zs\(0x\)\?\d\+\ze\n')
+	return (active_window =~ '^\(0x\)\?\d\+$' ? active_window : "")
 endfunction
 
 " MAC: Detection function for Mac OSX, uses osascript


### PR DESCRIPTION
Detect the window id by finding vim's pid (as for tmux), then inspect
its environment to get the value of WINDOWID.