### PR TITLE
Add missing argument to substitute() call

### DIFF
--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -132,7 +132,7 @@ function! AS_DetectActiveWindow_Tmux (swapname)
 	if (len(tty) == 0)
 		return ''
 	endif
-	let tty[0] = substitute(tty[0], '\s\+$', '')
+	let tty[0] = substitute(tty[0], '\s\+$', '', '')
 	" The output of `ps -o tt` and `tmux-list panes` varies from
 	" system to system.
 	" * Linux: `pts/1`, `/dev/pts/1`


### PR DESCRIPTION
The `substitute()` function requires 4 arguments.

After changing this, autoswap works for me again with tmux on macOS (e6c0f07).