### PR TITLE
Add support for iTerm2, and some other MacOS improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The original version of this plugin (only for Mac OX) is available at <http://is
 together with other plugins presented in the same talk. This version has
 been modified to work also on Linux systems. Both Vim and GVim are supported.
 
+Limitations
+-----------
+
+At the moment this plugin does not reliably detect files open within tabs in
+Apple Terminal and iTerm2 as it matches based on the window name, not tab name.
+
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin does for you what you would do in these cases:
 Damian Conway presented this plugin at OSCON 2013 in his talk
 "[More instantly better Vim](http://programming.oreilly.com/2013/10/more-instantly-better-vim.html)".
 
-The original version of this plugin (only for Mac OX) is available at <http://is.gd/IBV2013>,
+The original version of this plugin (only for MacOS) is available at <http://is.gd/IBV2013>,
 together with other plugins presented in the same talk. This version has
 been modified to work also on Linux systems. Both Vim and GVim are supported.
 

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -193,3 +193,5 @@ endfunction
 
 " Restore previous external compatibility options
 let &cpo = s:save_cpo
+
+" vim: noexpandtab tabstop=4 softtabstop=4 shiftwidth=4

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -10,8 +10,10 @@
 "##                                                         ##
 "##     set title titlestring=                              ##
 "##                                                         ##
-"##  On MacOS X this plugin works only for Vim sessions     ##
-"##  running in Terminal.                                   ##
+"##  On MacOS this plugin only works fully for Vim sessions ##
+"##  running in Apple Terminal or iTerm2. Other terminals   ##
+"##  and GUI Vims are partially supported, but detecting    ##
+"##  and switching to the active window will not work.      ##
 "##                                                         ##
 "##  On Linux this plugin requires the external program     ##
 "##  wmctrl, packaged for most distributions.               ##

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -155,6 +155,9 @@ endfunction
 
 " MAC: Detection function for Mac OSX, uses osascript
 function! AS_DetectActiveWindow_Mac (filename)
+	if ($TERM_PROGRAM != 'Apple_Terminal')
+		return ''
+	endif
 	let shortname = fnamemodify(a:filename,":t")
 	let active_window = system('osascript -e ''tell application "Terminal" to every window whose (name begins with "'.shortname.' " and name ends with "VIM")''')
 	let active_window = substitute(active_window, '^window id \d\+\zs\_.*', '', '')

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -159,7 +159,7 @@ function! AS_DetectActiveWindow_Mac (filename)
 		return ''
 	endif
 	let shortname = fnamemodify(a:filename,":t")
-	let active_window = system('osascript -e ''tell application "Terminal" to every window whose (name begins with "'.shortname.' " and name ends with "VIM")''')
+	let active_window = system('osascript -e ''tell application "Terminal" to every window whose (name begins with "'.shortname.' " and name contains "VIM")''')
 	let active_window = substitute(active_window, '^window id \d\+\zs\_.*', '', '')
 	return (active_window =~ 'window' ? active_window : "")
 endfunction


### PR DESCRIPTION
Hi,

I've added support for iTerm2, and made a few other small improvements for MacOS users.

AppleScript support differs in iTerm2 and Apple Terminal, which is why the previous attempt in branch `any-terminal-macos` failed to work as expected. Also, Hyper terminal does not natively support AppleScript, which is why the code in the same branch didn't work for Hyper.

My changes add explicit support for iTerm2, while retaining basic support for other terminals or GUI programs on MacOS (won't switch to active window, but will at least delete old swap files and open read-only, and without launching Apple Terminal when the user is not using it).

As per Apple Terminal support, the iTerm2 code does not work reliably with tabs as it relies on the window name to match. I've added a note to the readme to explain this limitation (though I think I can fix that issue in iTerm2, it's probably best to leave it for another time).

Fixes #11