### PR TITLE
better neovim (specifically neovim-qt) support

### DIFF
--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -75,8 +75,14 @@ endfunction
 
 function! Exit()
 	if has("nvim") && exists("*GuiClose")
-		let v:swapchoice = 'o'
-		autocmd BufEnter * call GuiClose() | qall!
+		let l:num_buffers = len(getbufinfo({'buflisted':1}))
+		let l:num_windows = winnr('$')
+		if l:num_buffers == 1 && l:num_windows == 1
+			let v:swapchoice = 'o'
+			autocmd BufEnter * call GuiClose() | q
+		else
+			let v:swapchoice = 'q'
+		endif
 	else
 		let v:swapchoice = 'q'
 	endif

--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -57,7 +57,7 @@ function! AS_HandleSwapfile (filename, swapname)
 	if (strlen(active_window) > 0)
 		call AS_DelayedMsg('Switched to existing session in another window')
 		call AS_SwitchToActiveWindow(active_window)
-		let v:swapchoice = 'q'
+		call Exit()
 
 	" Otherwise, if swapfile is older than file itself, just get rid of it...
 	elseif getftime(v:swapname) < getftime(a:filename)
@@ -72,6 +72,15 @@ function! AS_HandleSwapfile (filename, swapname)
 	endif
 endfunction
 
+
+function! Exit()
+	if has("nvim") && exists("*GuiClose")
+		let v:swapchoice = 'o'
+		autocmd BufEnter * call GuiClose() | qall!
+	else
+		let v:swapchoice = 'q'
+	endif
+endfunction
 
 " Print a message after the autocommand completes
 " (so you can see it, but don't have to hit <ENTER> to continue)...


### PR DESCRIPTION
neovim-qt hangs with a 'Neovim exited with status (...)' message when neovim exits with a non-zero exit code and setting `v:swapchoice = 'q'` or `v:swapchoice = 'a'` results in an exit code of 1.

Just calling `GuiClose` doesn't seem to work. Probably because the 'swap file exists' message is blocking it somehow? The workaround to open the file isn't perfect but seems to work pretty well for me.