### PR TITLE
Use accurate file matching on Linux

### DIFF
--- a/plugin/autoswap.vim
+++ b/plugin/autoswap.vim
@@ -147,10 +147,11 @@ function! AS_DetectActiveWindow_Tmux (swapname)
 	return window[0]
 endfunction
 
-" LINUX: Detection function for Linux, uses mwctrl
+" LINUX: Detection function for Linux, uses wmctrl
 function! AS_DetectActiveWindow_Linux (filename)
-	let shortname = fnamemodify(a:filename,":t")
-	let find_win_cmd = 'wmctrl -l | grep -i " '.shortname.' .*vim" | tail -n1 | cut -d" " -f1'
+	let basename = fnamemodify(a:filename,":t")
+	let dirname = fnamemodify(a:filename,":p:h")
+	let find_win_cmd = 'wmctrl -l | grep " '.basename.' ('.dirname.') - G\?VIM" | tail -n1 | cut -d" " -f1'
 	let active_window = system(find_win_cmd)
 	return (active_window =~ '0x' ? active_window : "")
 endfunction


### PR DESCRIPTION
This resolves issue #18, at least for Linux.  The window matching (via
wmctrl) had the following problems:

- it was not case sensitive, yet Linux file systems generally are

- it matched only the base name, ignoring the path which led to false
matches

Signed-off-by: John Florian <john_florian@dart.biz>